### PR TITLE
docs: update install section with curl installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ Without Crux, managing MCPs at scale looks like this:
 ## Install
 
 ```bash
+curl -LsSf https://raw.githubusercontent.com/crux-cli/crux/main/install.sh | sh
+```
+
+The installer checks for [uv](https://docs.astral.sh/uv/), installs it if missing, pulls `crux-cli` from PyPI, initialises `~/.crux/`, and tells you exactly what to do next (PATH fix, skill install).
+
+**Alternatively**, if you already have uv:
+
+```bash
 uv tool install crux-cli
 crux setup
 ```


### PR DESCRIPTION
## Summary
- Leads with the curl one-liner install command as the primary install path
- Keeps `uv tool install crux-cli` as an alternative for users who already have uv
- References the installer's behaviour (checks/installs uv, runs `crux setup`, prints PATH guidance)

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm curl install command matches `install.sh` location on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)