### PR TITLE
docs: improve homepage narrative and mermaid architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,114 +1,79 @@
 # Crux
 
-**Your AI agents have access to 10,000+ MCP servers. They should only see five.**
+**The package manager for AI agent tooling.**
 
 [![CI](https://github.com/crux-cli/crux/actions/workflows/ci.yml/badge.svg)](https://github.com/crux-cli/crux/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/crux-cli)](https://pypi.org/project/crux-cli/)
+[![Docs](https://img.shields.io/badge/docs-crux--cli.github.io-blue)](https://crux-cli.github.io/crux)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 ---
 
-The MCP ecosystem has exploded — 10,000+ servers, 60,000+ skills, and counting. But there's no way to manage them. API keys sit in plaintext config files. Every project gets the same 50 MCPs dumped into its context, whether it needs them or not. Your research agent can accidentally call your trading API. Setting up a new project means copy-pasting `.mcp.json` and praying nothing leaks.
+Your agents use dozens of MCP servers and skills. Crux manages them the way `npm` manages packages — one manifest, scoped per project, credentials never in files.
 
-**Crux is the control plane that sits between your MCP ecosystem and your AI agents.** One registry. Per-project scoping. Secrets in your OS keychain — never in files. Sandboxed execution. Full lifecycle management for every tool your agents touch.
+## The problem
 
-> Think `package.json` for AI tooling — declare what each project needs, and Crux handles the rest.
-
-## The Problem Crux Solves
-
-Without Crux, managing MCPs at scale looks like this:
+You have 30 MCP servers across 8 projects. Each project needs a different subset. Your research agent accidentally called the trading API because all MCPs were globally visible. API keys sit in `.env` files committed to git. Setting up a new project means 30 minutes of config editing instead of 30 seconds.
 
 | Pain | What happens |
 |------|-------------|
-| **Configuration sprawl** | 20 projects × 50 MCPs = 20 hand-maintained `.mcp.json` files. Add a new MCP? Edit every project. |
-| **Credential leakage** | 48% of MCP servers recommend storing API keys in plaintext. Keys end up committed to git, leaked in logs. |
-| **No scoping** | Every agent sees every tool. A coding assistant gets your home automation MCPs. A wiki bot gets filesystem write access. More tools = more noise = worse outputs. |
-| **No reproducibility** | You can't `git clone` a project and get its MCP setup. There's no `npm install` for AI tooling. |
-| **Skills are unmanaged** | 60,000+ Claude Code skills exist as files you manually copy between machines. No versioning. No scoping. No package management. |
+| **Configuration sprawl** | 20 projects x 50 MCPs = 20 hand-maintained `.mcp.json` files |
+| **Credential leakage** | 48% of MCP servers recommend storing API keys in plaintext |
+| **No scoping** | Every agent sees every tool — more noise, worse outputs, security risk |
+| **No reproducibility** | No `npm install` equivalent for AI tooling |
+| **Skills are unmanaged** | 60,000+ skills as files you manually copy between machines |
 
-**Scoping isn't just organization — it's a quality lever.** An agent with 5 relevant tools outperforms one drowning in 50 irrelevant ones. Less noise in the context window means better outputs, fewer hallucinated tool calls, and tighter security.
-## Install
-
-```bash
-curl -LsSf https://raw.githubusercontent.com/crux-cli/crux/main/install.sh | sh
-```
-
-The installer checks for [uv](https://docs.astral.sh/uv/), installs it if missing, pulls `crux-cli` from PyPI, initialises `~/.crux/`, and tells you exactly what to do next (PATH fix, skill install).
-
-**Alternatively**, if you already have uv:
+## The solution
 
 ```bash
-uv tool install crux-cli
-crux setup
-```
-
-## Workflow: Set Up a Project in 30 Seconds
-
-You have a homelab assistant that needs wiki access and filesystem tools — nothing else.
-
-```bash
-# Add MCPs to your personal registry (once, ever)
+# Build your personal tool registry (once, ever)
 crux add mcp filesystem --npx @modelcontextprotocol/server-filesystem
 crux add mcp wikijs --github jaalbin24/wikijs-mcp-server
+crux add skill autoresearch --github user/autoresearch-skill
 
-# Store credentials in your OS keychain — not in files
+# Credentials go in your OS keychain — never in files
 crux secret set wikijs WIKIJS_API_KEY
-# → prompts securely, stores in macOS Keychain / Linux Secret Service
 
-# Create a project — it gets exactly what it needs
+# Each project declares exactly what it needs
 crux init homelab-assistant && cd homelab-assistant
-crux install wikijs filesystem
+crux install wikijs filesystem autoresearch
 crux status
 ```
 
-That's it. Your project now has a `crux.json` (committed to git) and a generated `.mcp.json` (gitignored) ready for Claude Code. The wiki MCP launches via a generated script that fetches your API key from the keychain at runtime. No secrets ever touch a file.
+Your project now has a `crux.json` (committed to git) and a generated `.mcp.json` (gitignored). When a teammate clones the repo, they run `crux install` and get the same setup — with their own credentials from their own keychain.
 
-## Workflow: Run an Agent in a Sandbox
+## Architecture
 
-Your research agent should only access the wiki and a research skill — no filesystem, no GitHub, no trading APIs.
+```mermaid
+graph LR
+    subgraph Discovery
+        S1[Official MCP Registry]
+        S2[npm / PyPI]
+        S3[GitHub Repos]
+        S4[Local Sources]
+    end
 
-```bash
-# Ad-hoc sandboxed run
-crux run "Find papers on MCP security and update the wiki" \
-  --mcps wikijs filesystem \
-  --skills autoresearch
+    subgraph Crux[Crux Control Plane]
+        REG[Registry\nMCPs + Skills]
+        SEC[Secrets\nOS Keychain]
+        SYN[Sync Engine]
+    end
 
-# Or save it as a reusable manifest (committed to git)
-cat > tasks/weekly-research.json << 'EOF'
-{
-  "name": "weekly-research",
-  "task": "Search for latest MCP security papers, summarize, update wiki",
-  "mcps": ["wikijs", "filesystem"],
-  "skills": ["autoresearch"],
-  "timeout_minutes": 30
-}
-EOF
+    subgraph Projects
+        P1[Project A\nwikijs, filesystem]
+        P2[Project B\ngithub, memory]
+        P3[Sandbox Run\nscoped access]
+    end
 
-crux run --file tasks/weekly-research.json
-```
-
-Before execution, Crux runs pre-flight checks — every MCP exists, every secret is stored, every source is built. If something's missing, you get the exact command to fix it. No wasted agent time on mid-run failures.
-
-## How It Works
-
-```
-  You discover MCPs           Crux manages them             Your agents use them
-┌──────────────────┐    ┌───────────────────────┐    ┌──────────────────────┐
-│  Smithery        │    │  crux add             │    │                      │
-│  Official Reg.   │───▶│  ┌─ registry.json ──┐ │    │  Project A           │
-│  GitHub          │    │  │ wikijs, github,   │ │    │  crux.json:          │
-│  npm / PyPI      │    │  │ filesystem, slack │ │    │    wikijs, filesystem │
-└──────────────────┘    │  │ memory, trading   │ │    │  → .mcp.json (2 MCPs)│
-                        │  └───────────────────┘ │    │                      │
-                        │                        │    │  Project B           │
-                        │  crux secret set       │    │  crux.json:          │
-                        │  ┌─ OS Keychain ─────┐ │    │    github, memory    │
-                        │  │ API keys, tokens  │ │    │  → .mcp.json (2 MCPs)│
-                        │  │ (never in files)  │ │    │                      │
-                        │  └───────────────────┘ │    │  Sandbox Run         │
-                        │                        │    │  crux run --mcps ... │
-                        │  crux sync / crux run  │    │  → scoped .mcp.json  │
-                        └───────────────────────┘    └──────────────────────┘
+    S1 --> REG
+    S2 --> REG
+    S3 --> REG
+    S4 --> REG
+    REG --> SYN
+    SEC --> SYN
+    SYN --> P1
+    SYN --> P2
+    SYN --> P3
 ```
 
 **Registry** — Add MCPs and skills once from npm, PyPI, GitHub, or local sources. One source of truth across all projects.
@@ -120,6 +85,37 @@ Before execution, Crux runs pre-flight checks — every MCP exists, every secret
 **Sandboxed execution** — `crux run` creates isolated environments where agents only see the MCPs you declare. Pre-flight validation catches misconfigurations before execution starts.
 
 **Health monitoring** — `crux status` probes every MCP via JSON-RPC handshake. `crux doctor` validates your entire environment and auto-fixes what it can.
+
+## Why scoping matters
+
+**An agent with 5 relevant tools outperforms one drowning in 50 irrelevant ones.** Less noise in the context window means better outputs, fewer hallucinated tool calls, and tighter security. Scoping isn't just organization — it's a quality lever.
+
+## Install
+
+```bash
+curl -LsSf https://raw.githubusercontent.com/crux-cli/crux/main/install.sh | sh
+```
+
+The installer checks for [uv](https://docs.astral.sh/uv/), installs it if missing, pulls `crux-cli` from PyPI, initialises `~/.crux/`, and tells you exactly what to do next.
+
+**Alternatively**, if you already have uv:
+
+```bash
+uv tool install crux-cli
+crux setup
+```
+
+## Run an agent in a sandbox
+
+Your research agent should only access the wiki and a research skill — no filesystem, no GitHub, no trading APIs.
+
+```bash
+crux run "Find papers on MCP security and update the wiki" \
+  --mcps wikijs \
+  --skills autoresearch
+```
+
+Before execution, Crux runs pre-flight checks — every MCP exists, every secret is stored, every source is built. If something's missing, you get the exact command to fix it.
 
 ## Commands
 
@@ -163,21 +159,23 @@ Crux takes an opinionated stance: **there is no insecure-but-easier path.**
 - Launcher scripts contain keystore lookup commands, not credential values
 - Generated `.mcp.json` never contains secrets
 - Each sandbox gets only the MCPs explicitly declared for that run
-- `crux doctor` warns if it detects plaintext credentials anywhere in your config
 - Path traversal protections on all file operations
 
-In an ecosystem where [48% of MCP servers recommend plaintext credential storage](https://www.stackone.com/blog/mcp-security-risks), Crux makes secure-by-default the only option.
-
-## Why Not Just...
+## Why not just...
 
 | Alternative | What's missing |
 |------------|---------------|
-| Edit `.mcp.json` by hand | No scoping, no secrets management, config drift across projects, no reproducibility |
-| Smithery / PulseMCP | Discovery platforms — they help you *find* MCPs, not *manage* them across projects |
-| Docker MCP Gateway | Container isolation only — no registry, no per-project scoping, no credential management |
-| MCPM | Profile-based — no project-level manifest, no keystore secrets, no sandboxed execution |
+| Edit `.mcp.json` by hand | No scoping, no secrets management, config drift, no reproducibility |
+| Smithery / PulseMCP | Discovery platforms — they help you *find* MCPs, not *manage* them |
+| Docker MCP Gateway | Container isolation only — no registry, no scoping, no credentials |
+| MCPM | Profile-based — no project manifests, no keystore secrets, no sandbox |
 
 Crux is the full lifecycle: **curate → scope → secure → execute → monitor.**
+
+## Documentation
+
+Full docs, guides, and API reference at [crux-cli.github.io/crux](https://crux-cli.github.io/crux).
+
 ## Development
 
 ```bash
@@ -187,10 +185,6 @@ uv sync --extra dev
 uv run pytest tests/ -v
 uv run ruff check src/crux_cli/ tests/
 ```
-
-## Documentation
-
-Full docs, guides, and API reference at [docs.crux.dev](https://docs.crux.dev) *(coming soon)*.
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,86 +1,163 @@
 ---
 hide:
   - navigation
+  - toc
 ---
 
 # Crux
 
-**Your AI agents have access to 10,000+ MCP servers. They should only see five.**
+## The package manager for AI agent tooling
+
+Your agents use dozens of MCP servers and skills. Crux manages them the way `npm` manages packages — one manifest, scoped per project, credentials never in files.
 
 <div class="grid cards" markdown>
 
--   :material-download:{ .lg .middle } __Install in seconds__
+-   :material-package-variant:{ .lg .middle } __One registry, every project__
 
     ---
 
-    One command to install. Works on macOS and Linux.
+    Add MCPs from npm, PyPI, or GitHub once. Every project draws from the same source of truth — no more copy-pasting `.mcp.json` between repos.
 
-    [:octicons-arrow-right-24: Installation](getting-started/installation.md)
+    [:octicons-arrow-right-24: Registry](guides/registry.md)
 
--   :material-rocket-launch:{ .lg .middle } __Get started in 30 seconds__
-
-    ---
-
-    Add MCPs, create a project, install tools — done.
-
-    [:octicons-arrow-right-24: Quick Start](getting-started/quickstart.md)
-
--   :material-shield-lock:{ .lg .middle } __Secure by default__
+-   :material-shield-lock:{ .lg .middle } __Secrets that never touch disk__
 
     ---
 
-    Secrets in your OS keychain. Never in files. No insecure-but-easier path.
+    API keys live in your OS keychain. Launcher scripts fetch them at runtime. Nothing is ever written to a config file.
 
-    [:octicons-arrow-right-24: Secrets Management](guides/secrets.md)
+    [:octicons-arrow-right-24: Secrets](guides/secrets.md)
 
--   :material-cube-outline:{ .lg .middle } __Sandboxed execution__
+-   :material-file-document-check:{ .lg .middle } __Declarative project manifests__
 
     ---
 
-    Run agents with exactly the MCPs they need. Nothing more.
+    `crux.json` declares what each project needs. `crux sync` generates the rest. Clone, install, done — like `package.json` for AI tooling.
 
-    [:octicons-arrow-right-24: Sandbox Guide](guides/sandbox.md)
+    [:octicons-arrow-right-24: Projects](guides/projects.md)
+
+-   :material-cube-outline:{ .lg .middle } __Scoped, sandboxed execution__
+
+    ---
+
+    Each agent sees only the tools it needs. Less noise in the context window means better outputs and fewer hallucinated tool calls.
+
+    [:octicons-arrow-right-24: Sandbox](guides/sandbox.md)
 
 </div>
 
 ---
 
-Crux is the **control plane** that sits between your MCP ecosystem and your AI agents. One registry. Per-project scoping. Secrets in your OS keychain — never in files. Sandboxed execution. Full lifecycle management for every tool your agents touch.
+## The problem Crux solves
 
-> Think `package.json` for AI tooling — declare what each project needs, and Crux handles the rest.
+You have 30 MCP servers across 8 projects. Each project needs a different subset. Your research agent accidentally called the trading API because all MCPs were globally visible. API keys sit in `.env` files committed to git. Setting up a new project means 30 minutes of config editing.
+
+**Crux fixes this with one workflow:**
 
 ```bash
-# Add MCPs to your personal registry (once, ever)
+# Build your personal tool registry (once, ever)
 crux add mcp filesystem --npx @modelcontextprotocol/server-filesystem
 crux add mcp wikijs --github jaalbin24/wikijs-mcp-server
+crux add skill autoresearch --github user/autoresearch-skill
 
-# Store credentials in your OS keychain — not in files
+# Credentials go in your OS keychain — never in files
 crux secret set wikijs WIKIJS_API_KEY
 
-# Create a project — it gets exactly what it needs
+# Each project declares exactly what it needs
 crux init homelab-assistant && cd homelab-assistant
-crux install wikijs filesystem
-crux status
+crux install wikijs filesystem autoresearch
 ```
 
-## How It Works
+That's it. Your project has a `crux.json` (committed to git) and a generated `.mcp.json` (gitignored). When a teammate clones the repo, they run `crux install` and get the same setup — with their own credentials from their own keychain.
 
+---
+
+## Architecture
+
+``` mermaid
+graph LR
+    subgraph Discovery["Discovery Sources"]
+        direction TB
+        S1["Official MCP Registry"]
+        S2["npm / PyPI"]
+        S3["GitHub Repos"]
+        S4["Local Sources"]
+    end
+
+    subgraph Crux["Crux Control Plane"]
+        direction TB
+        REG["Registry<br/><code>~/.crux/registry.json</code><br/>MCPs + Skills"]
+        SEC["Secrets<br/>OS Keychain<br/><em>never in files</em>"]
+        SYN["Sync Engine<br/><code>crux sync</code><br/>Generates .mcp.json + launchers"]
+    end
+
+    subgraph Projects["Your Projects"]
+        direction TB
+        P1["<strong>Project A</strong><br/><code>crux.json</code>: wikijs, filesystem<br/>→ .mcp.json <em>(2 MCPs)</em>"]
+        P2["<strong>Project B</strong><br/><code>crux.json</code>: github, memory<br/>→ .mcp.json <em>(2 MCPs)</em>"]
+        P3["<strong>Sandbox Run</strong><br/><code>crux run --mcps ...</code><br/>→ scoped .mcp.json"]
+    end
+
+    S1 --> REG
+    S2 --> REG
+    S3 --> REG
+    S4 --> REG
+    REG --> SYN
+    SEC --> SYN
+    SYN --> P1
+    SYN --> P2
+    SYN --> P3
+
+    style Discovery fill:#e8eaf6,stroke:#5c6bc0,color:#1a237e
+    style Crux fill:#f3e5f5,stroke:#8e24aa,color:#4a148c
+    style Projects fill:#e8f5e9,stroke:#43a047,color:#1b5e20
+    style REG fill:#ede7f6,stroke:#7e57c2,color:#311b92
+    style SEC fill:#fce4ec,stroke:#e53935,color:#b71c1c
+    style SYN fill:#ede7f6,stroke:#7e57c2,color:#311b92
+    style S1 fill:#e8eaf6,stroke:#5c6bc0,color:#1a237e
+    style S2 fill:#e8eaf6,stroke:#5c6bc0,color:#1a237e
+    style S3 fill:#e8eaf6,stroke:#5c6bc0,color:#1a237e
+    style S4 fill:#e8eaf6,stroke:#5c6bc0,color:#1a237e
+    style P1 fill:#e8f5e9,stroke:#43a047,color:#1b5e20
+    style P2 fill:#e8f5e9,stroke:#43a047,color:#1b5e20
+    style P3 fill:#e8f5e9,stroke:#43a047,color:#1b5e20
 ```
-  You discover MCPs           Crux manages them             Your agents use them
-┌──────────────────┐    ┌───────────────────────┐    ┌──────────────────────┐
-│  Smithery        │    │  crux add             │    │                      │
-│  Official Reg.   │───▶│  ┌─ registry.json ──┐ │    │  Project A           │
-│  GitHub          │    │  │ wikijs, github,   │ │    │  crux.json:          │
-│  npm / PyPI      │    │  │ filesystem, slack │ │    │    wikijs, filesystem │
-└──────────────────┘    │  │ memory, trading   │ │    │  → .mcp.json (2 MCPs)│
-                        │  └───────────────────┘ │    │                      │
-                        │                        │    │  Project B           │
-                        │  crux secret set       │    │  crux.json:          │
-                        │  ┌─ OS Keychain ─────┐ │    │    github, memory    │
-                        │  │ API keys, tokens  │ │    │  → .mcp.json (2 MCPs)│
-                        │  │ (never in files)  │ │    │                      │
-                        │  └───────────────────┘ │    │  Sandbox Run         │
-                        │                        │    │  crux run --mcps ... │
-                        │  crux sync / crux run  │    │  → scoped .mcp.json  │
-                        └───────────────────────┘    └──────────────────────┘
+
+---
+
+## Why scoping matters
+
+Scoping isn't just organization — it's a **quality lever**.
+
+An agent with 5 relevant tools consistently outperforms one drowning in 50 irrelevant ones. Less noise in the context window means:
+
+- **Better outputs** — the model focuses on relevant tools
+- **Fewer hallucinated tool calls** — no accidental calls to the trading API from your wiki bot
+- **Tighter security** — each agent's blast radius is limited to what it actually needs
+- **Faster execution** — smaller tool lists mean faster MCP initialization
+
+---
+
+## Install
+
+```bash
+curl -LsSf https://raw.githubusercontent.com/crux-cli/crux/main/install.sh | sh
 ```
+
+Or with uv: `uv tool install crux-cli && crux setup`
+
+[:octicons-arrow-right-24: Full installation guide](getting-started/installation.md)
+
+---
+
+## The full lifecycle
+
+**Curate** :material-arrow-right: **Scope** :material-arrow-right: **Secure** :material-arrow-right: **Execute** :material-arrow-right: **Monitor**
+
+| Stage | What Crux does | Command |
+|-------|---------------|---------|
+| **Curate** | Build a personal registry of MCPs and skills from any source | `crux add`, `crux search` |
+| **Scope** | Each project declares exactly what it needs in `crux.json` | `crux init`, `crux install` |
+| **Secure** | Credentials in OS keychain, fetched at runtime by launcher scripts | `crux secret set` |
+| **Execute** | Run agents in sandboxes with only the declared MCPs | `crux run` |
+| **Monitor** | Health-check MCP servers, diagnose and auto-fix issues | `crux status`, `crux doctor` |

--- a/docs/why-crux.md
+++ b/docs/why-crux.md
@@ -1,48 +1,68 @@
 # Why Crux
 
-The MCP ecosystem has exploded — 10,000+ servers, 60,000+ skills, and counting. But there's no way to manage them.
+## The MCP management crisis
 
-## The Problem
+The MCP ecosystem has exploded — 10,000+ servers, 60,000+ skills, and counting. But there's no way to manage them at scale.
 
-Without Crux, managing MCPs at scale looks like this:
+Meet Alex, a developer building multi-agent workflows. They have 30+ MCPs across 8 projects, API keys for 15 services scattered across config files, and a research agent that once accidentally called the trading API because all MCPs were globally visible. Setting up a new project means copying `.mcp.json` by hand, editing it for 30 minutes, and hoping nothing leaks.
 
-| Pain | What happens |
-|------|-------------|
-| **Configuration sprawl** | 20 projects x 50 MCPs = 20 hand-maintained `.mcp.json` files. Add a new MCP? Edit every project. |
-| **Credential leakage** | 48% of MCP servers recommend storing API keys in plaintext. Keys end up committed to git, leaked in logs. |
-| **No scoping** | Every agent sees every tool. A coding assistant gets your home automation MCPs. A wiki bot gets filesystem write access. More tools = more noise = worse outputs. |
-| **No reproducibility** | You can't `git clone` a project and get its MCP setup. There's no `npm install` for AI tooling. |
-| **Skills are unmanaged** | 60,000+ Claude Code skills exist as files you manually copy between machines. No versioning. No scoping. No package management. |
+Alex's story isn't unusual. Every developer building with AI agents hits the same wall.
 
-## Scoping Is a Quality Lever
+## Five problems that compound
 
-**An agent with 5 relevant tools outperforms one drowning in 50 irrelevant ones.** Less noise in the context window means better outputs, fewer hallucinated tool calls, and tighter security.
+| # | Problem | What happens at scale |
+|---|---------|----------------------|
+| 1 | **Configuration sprawl** | 20 projects x 50 MCPs = 20 hand-maintained `.mcp.json` files. Add a new MCP? Edit every project. |
+| 2 | **Credential leakage** | 48% of MCP servers recommend storing API keys in plaintext. Keys end up committed to git, leaked in logs. |
+| 3 | **No scoping** | Every agent sees every tool. A coding assistant gets home automation MCPs. A wiki bot gets filesystem write access. More tools = more noise = worse outputs. |
+| 4 | **No reproducibility** | You can't `git clone` a project and get its MCP setup. There's no `npm install` for AI tooling. |
+| 5 | **Skills are unmanaged** | 60,000+ Claude Code skills exist as files you manually copy between machines. No versioning, no scoping, no package management. |
 
-## Why Not Just...
+## Scoping is a quality lever
+
+This is the core insight behind Crux: **limiting what an agent can see makes it better at what it does.**
+
+An agent with 5 relevant tools consistently outperforms one with 50 irrelevant ones:
+
+- **Better outputs** — the model focuses on tools that matter for the task
+- **Fewer hallucinated tool calls** — no accidental calls to your trading API from a wiki bot
+- **Tighter security** — each agent's blast radius is limited to what it actually needs
+- **Faster execution** — smaller tool lists mean faster MCP initialization and less context overhead
+
+Scoping isn't a restriction. It's an optimization.
+
+## What Crux does
+
+Crux applies patterns you already know — `package.json`, `direnv`, Homebrew — to AI agent tooling:
+
+| Pattern | Analogy | What Crux does |
+|---------|---------|---------------|
+| **Tool registry** | Homebrew / mise | Install, upgrade, and manage MCPs and skills from any source |
+| **Project manifest** | package.json + npm | Per-project declarative config, git-versionable, reproducible |
+| **Secret binding** | direnv + OS keystore | Credentials bound to MCPs, never in files, resolved at runtime |
+| **Sandboxed execution** | *(new)* | Run an agent with exactly the MCPs it needs and nothing else |
+
+## What Crux is NOT
+
+- **Not a marketplace.** There is no Crux-hosted registry. Use Smithery, PulseMCP, or the official MCP registry to *discover* tools. Crux manages what you've already chosen.
+- **Not a cloud service.** All configuration lives on your machine.
+- **Not competing with MCP discovery platforms.** Crux starts where discovery ends.
+
+## Why not just...
 
 | Alternative | What's missing |
 |------------|---------------|
 | Edit `.mcp.json` by hand | No scoping, no secrets management, config drift across projects, no reproducibility |
-| Smithery / PulseMCP | Discovery platforms — they help you *find* MCPs, not *manage* them across projects |
+| Smithery / PulseMCP | Discovery platforms — they help you *find* MCPs, not *manage* them |
 | Docker MCP Gateway | Container isolation only — no registry, no per-project scoping, no credential management |
 | MCPM | Profile-based — no project-level manifest, no keystore secrets, no sandboxed execution |
 
-## Crux Is the Full Lifecycle
+## The full lifecycle
 
-**Curate → Scope → Secure → Execute → Monitor.**
+**Curate → Scope → Secure → Execute → Monitor**
 
-- **Registry**: Add MCPs and skills once from npm, PyPI, GitHub, or local sources. One source of truth across all projects.
-- **Project scoping**: Each project declares exactly which MCPs and skills it needs in `crux.json`. No ambient access.
-- **Secrets**: Credentials live in your OS keystore. Generated launcher scripts fetch them at runtime. Nothing is ever written to disk.
-- **Sandboxed execution**: `crux run` creates isolated environments where agents only see the MCPs you declare.
-- **Health monitoring**: `crux status` probes every MCP via JSON-RPC. `crux doctor` validates your entire environment.
-
-## Security Stance
-
-Crux takes an opinionated stance: **there is no insecure-but-easier path.**
-
-- Secrets never appear in any file on disk — only in your OS keystore
-- Launcher scripts contain keystore lookup commands, not credential values
-- Generated `.mcp.json` never contains secrets
-- Each sandbox gets only the MCPs explicitly declared for that run
-- Path traversal protections on all file operations
+1. **Curate** — Build a personal registry of MCPs and skills. Add from npm, PyPI, GitHub, or local sources. One source of truth across all projects.
+2. **Scope** — Each project declares exactly which MCPs and skills it needs in `crux.json`. Agents only see what's declared.
+3. **Secure** — Credentials live in your OS keystore. Launcher scripts fetch them at runtime. Nothing is ever written to disk.
+4. **Execute** — `crux run` creates sandboxes where agents only access declared MCPs. Pre-flight checks catch misconfigurations before execution.
+5. **Monitor** — `crux status` probes every MCP via JSON-RPC. `crux doctor` validates your entire environment and auto-fixes what it can.


### PR DESCRIPTION
## Summary

- **New tagline**: "The package manager for AI agent tooling" — positions Crux with a familiar mental model
- **Mermaid architecture diagram** replacing ASCII art — shows full flow from discovery sources through registry/secrets/sync to scoped projects, with professional color theming
- **Skills management** included throughout (architecture diagram, code examples, lifecycle table)
- **User story** leading the narrative — concrete pain points (30 MCPs across 8 projects, accidental trading API calls, 30 minutes of setup) instead of abstract problem statements
- **"Why scoping matters" section** — explains the quality lever insight (better outputs, fewer hallucinations, tighter security, faster execution)
- **Full lifecycle table** — curate → scope → secure → execute → monitor with commands
- **README**: matching narrative overhaul, mermaid diagram, docs site badge
- **why-crux.md**: expanded with Alex persona, pattern analogies (Homebrew, package.json, direnv), "What Crux is NOT" section

## Test plan

- [x] `mkdocs build --strict` — clean build, no errors
- [x] 314 unit tests pass
- [ ] Visual check of mermaid diagram rendering on docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)