### PR TITLE
Update tagline to Agentic Tool Manager for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Crux
 
-**Manage your MCP servers and skills like packages.**
+**Agentic Tool Manager for Claude Code.**
 
 [![CI](https://github.com/crux-cli/crux/actions/workflows/ci.yml/badge.svg)](https://github.com/crux-cli/crux/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/crux-cli)](https://pypi.org/project/crux-cli/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 template: home.html
-title: Crux — Manage your MCP servers and skills like packages
+title: Crux — Agentic Tool Manager for Claude Code
 hide:
   - navigation
   - toc

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -20,7 +20,7 @@
       <div class="crux-hero__inner">
         <h1>Crux</h1>
         <p class="crux-hero__tagline">
-          Manage your MCP servers and skills like packages
+          Agentic Tool Manager for Claude Code
         </p>
         <p class="crux-hero__sub">
           A CLI tool for <strong>macOS</strong> and <strong>Linux</strong> that brings package&#8209;management to your <strong>Claude&nbsp;Code</strong> agentic workflows.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Crux — Agentic Tool Manager for Claude Code
 site_url: https://crux-cli.github.io/crux/
-site_description: "Manage your MCP servers and skills like packages. Per-project scoping, secure secrets, sandboxed execution for Claude Code."
+site_description: "Agentic Tool Manager for Claude Code. Per-project scoping, secure secrets, sandboxed execution."
 site_author: Crux CLI
 repo_url: https://github.com/crux-cli/crux
 repo_name: crux-cli/crux


### PR DESCRIPTION
## Summary
- Update tagline from "Manage your MCP servers and skills like packages" to "Agentic Tool Manager for Claude Code" across all 4 locations: mkdocs.yml, README.md, docs/index.md, home.html hero

🤖 Generated with [Claude Code](https://claude.com/claude-code)