### PR TITLE
feat: add review-pr, create-pr, and release-version skills

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: create-pr
+description: "Create a PR from the current branch with a structured description optimized for automated review."
+args: "[--draft] — optional flag to create as draft PR."
+---
+
+# Create PR
+
+Create a pull request from the current branch with a structured description that enables thorough automated review via `/review-pr`.
+
+## Prerequisites
+
+Verify before proceeding:
+
+1. You are on a feature branch (not main)
+2. All work is committed (`git status` is clean)
+3. Branch is pushed to remote
+
+If any prerequisite fails, fix it before continuing.
+
+## Step 1: Gather Context
+
+```bash
+# Current branch and base
+BRANCH=$(git branch --show-current)
+BASE="main"
+
+# All commits on this branch
+git log ${BASE}..HEAD --oneline
+
+# Full diff stats
+git diff ${BASE}...HEAD --stat
+
+# Changed files
+gh api repos/:owner/:repo/compare/${BASE}...${BRANCH} --jq '.files[].filename'
+```
+
+## Step 2: Analyze Changes
+
+Categorize every changed file into:
+
+- **Source code**: `src/` changes — what logic changed and why
+- **Tests**: `tests/` changes — what's covered, what test strategy was used
+- **Docs**: `docs/`, `README.md`, `CHANGELOG.md` — what documentation was updated
+- **Config**: `pyproject.toml`, workflow files, config — what infrastructure changed
+- **Skills**: `.claude/skills/` — what skills were added or modified
+
+## Step 3: Build PR Description
+
+Use this exact format. Every section is required. The `/review-pr` skill parses these sections.
+
+```markdown
+## Summary
+
+<1-3 sentences: what this PR does and why>
+
+## Changes
+
+### Source
+- <file>: <what changed and why>
+
+### Tests
+- <file>: <what's tested>
+
+### Docs
+- <file>: <what was updated>
+(Write "No doc changes" if none — reviewer will check if docs SHOULD have been updated)
+
+### Config
+- <file>: <what changed>
+(Write "No config changes" if none)
+
+## Breaking Changes
+
+<List any breaking changes to CLI flags, public APIs, or behavior. Write "None" if none.>
+
+## Security Considerations
+
+<List any security-relevant changes: auth, secrets, shell commands, user input handling. Write "None" if none.>
+
+## Test Plan
+
+- [ ] All unit tests pass (`uv run pytest tests/unit/ -v`)
+- [ ] All integration tests pass (`uv run pytest tests/integration/ -v`)
+- [ ] Ruff clean (`uv run ruff check src/ tests/`)
+- [ ] Coverage maintained (>90%)
+- [ ] No secrets in committed files
+<Add any PR-specific test steps>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+## Step 4: Push and Create PR
+
+```bash
+# Push branch if not already pushed
+git push -u origin HEAD
+
+# Create the PR (use --draft if argument was passed)
+gh pr create --title "<short title under 70 chars>" --body "<structured body from Step 3>"
+```
+
+The title should follow this convention:
+- `feat: <description>` — new feature
+- `fix: <description>` — bug fix
+- `refactor: <description>` — refactoring
+- `docs: <description>` — documentation only
+- `chore: <description>` — maintenance, deps, config
+
+## Step 5: Verify
+
+```bash
+gh pr view --web
+```
+
+Confirm the PR was created with the full structured description.
+
+## Notes
+
+- The structured format enables `/review-pr` to efficiently locate what changed, what's tested, and what docs need checking
+- Always fill in "Breaking Changes" and "Security Considerations" even if "None" — the reviewer checks these sections exist
+- If the PR is large (>500 lines), add a "Review Guide" section suggesting which files to review first

--- a/.claude/skills/release-version/SKILL.md
+++ b/.claude/skills/release-version/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: release-version
+description: "Bump version on main, tag, run release pipeline, then deploy docs. Auto-increments patch if no version given."
+args: "[version] — optional version number (e.g., 1.0.2). If omitted, increments the patch version by 1."
+---
+
+# Release Version
+
+Bump the version in `pyproject.toml` on main, tag the release, run the release pipeline, and deploy docs.
+
+## Step 0: Resolve Version
+
+If a version argument was provided, use it. Otherwise, auto-increment:
+
+```bash
+# Read current version from pyproject.toml
+CURRENT=$(grep -m1 '^version' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
+echo "Current version: $CURRENT"
+```
+
+If no version argument:
+- Parse `CURRENT` as `MAJOR.MINOR.PATCH`
+- Increment `PATCH` by 1
+- Set `VERSION` to `MAJOR.MINOR.(PATCH+1)`
+
+Example: `1.0.1` → `1.0.2`
+
+Verify `VERSION` is greater than `CURRENT`. If not, abort.
+
+## Step 1: Ensure Clean Main
+
+```bash
+git checkout main
+git pull origin main
+git status
+```
+
+Working tree must be clean. If not, abort with a message.
+
+## Step 2: Bump Version
+
+Update `pyproject.toml`:
+
+```python
+version = "<VERSION>"
+```
+
+Commit and push directly to main:
+
+```bash
+git add pyproject.toml
+git commit -m "chore: bump version to <VERSION>"
+git push origin main
+```
+
+## Step 3: Tag and Push
+
+```bash
+git tag v<VERSION>
+git push origin v<VERSION>
+```
+
+This triggers `.github/workflows/release.yml` which:
+- Runs full CI gate
+- Builds sdist + wheel
+- Publishes to PyPI
+- Creates GitHub Release
+
+## Step 4: Wait for Release Pipeline
+
+```bash
+# Find the run triggered by the tag
+gh run list --workflow=release.yml --limit=1
+gh run watch
+```
+
+If the release pipeline fails:
+1. Read failure logs: `gh run view <run-id> --log-failed`
+2. Report the failure and stop. Do NOT proceed to docs.
+
+## Step 5: Deploy Docs
+
+The docs pipeline does not auto-trigger from GitHub Actions releases. Dispatch manually:
+
+```bash
+gh workflow run docs.yml -f version=<VERSION>
+```
+
+Wait for docs deployment:
+
+```bash
+gh run list --workflow=docs.yml --limit=1
+gh run watch
+```
+
+## Step 6: Verify
+
+```bash
+# PyPI
+pip index versions crux-cli
+
+# GitHub Release
+gh release view v<VERSION>
+
+# Docs
+echo "Docs: https://crux-cli.github.io/crux/"
+```
+
+Report the version, PyPI status, and docs URL.
+
+## Rollback
+
+If tagged but release pipeline failed:
+
+```bash
+git tag -d v<VERSION>
+git push origin :refs/tags/v<VERSION>
+```
+
+If already published to PyPI, publish a patch fix instead — PyPI versions cannot be deleted.
+
+## Notes
+
+- This skill operates directly on main — no branch or PR involved
+- The release pipeline requires a PyPI trusted publisher configured in GitHub repo settings
+- The docs pipeline uses `mike` for versioned documentation
+- Always verify the release pipeline succeeds before deploying docs

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: review-pr
+description: "Review open PRs: CI gate, code review, security review, docs review. Approve or request changes."
+args: "[PR#] — optional PR number or URL. If omitted, reviews all open PRs."
+---
+
+# PR Review
+
+Review pull requests with a rigorous multi-phase process: CI gate, code review, security audit, and documentation check. Post findings as PR comments, then approve or request changes.
+
+## Invocation
+
+```
+/review-pr          # Review all open PRs
+/review-pr 42       # Review PR #42 only
+```
+
+## Step 0: Resolve Target PRs
+
+If a PR number is provided, use it. Otherwise, list all open PRs:
+
+```bash
+gh pr list --state open --json number,title,headRefName --limit 50
+```
+
+Run the full review process (Steps 1–5) for each PR sequentially.
+
+## Step 1: CI Gate (Hard Gate)
+
+Check whether all CI checks have passed:
+
+```bash
+gh pr checks <PR#>
+```
+
+- **All checks pass**: proceed to Step 2.
+- **Any check failing**: post a comment and request changes immediately. Do NOT proceed with code review.
+
+Comment on failure:
+```
+**[CRITICAL]** CI Pipeline
+
+CI checks are failing. Skipping code review until all checks pass.
+
+Failing checks:
+- <list each failing check and its status>
+
+Please fix CI failures and push again.
+```
+
+Skip to the next PR (if reviewing multiple).
+
+## Step 2: Code Review
+
+Read the full PR diff:
+
+```bash
+gh pr diff <PR#>
+```
+
+Also read the PR description and any linked issues for context:
+
+```bash
+gh pr view <PR#> --json title,body,labels,files
+```
+
+### 2a. Logic & Correctness
+
+Review every changed file for:
+
+- **Logical errors**: off-by-one, wrong conditionals, missing edge cases, race conditions
+- **Error handling**: uncaught exceptions, swallowed errors, missing validation at system boundaries
+- **State management**: uninitialized variables, stale state, mutation side effects
+- **API contracts**: breaking changes to public interfaces, missing backwards compatibility where needed
+- **Resource management**: unclosed files/connections, missing cleanup
+
+### 2b. Test Quality
+
+Review all test changes for:
+
+- **Shortcut detection**: tests that are written to pass rather than to verify behavior — e.g., testing implementation details, asserting on mocks instead of outcomes, trivially true assertions
+- **Coverage gaps**: new code paths without corresponding tests, missing edge case tests
+- **Test isolation**: tests depending on execution order, shared mutable state, flaky patterns
+- **Assertion quality**: meaningful assertions vs. trivially true checks, proper error message checks, boundary value testing
+
+### 2c. Code Style (per CONTRIBUTING.md)
+
+- Python 3.11+ modern syntax (`list[str]`, `str | None`)
+- Type annotations on public functions
+- Line length: 120 characters
+- Atomic file writes (temp file + rename) for JSON/TOML saves
+- Ruff rules compliance: E/F/W, I, UP, B, SIM, S
+
+## Step 3: Security Review
+
+Examine the diff for security issues. This is a thorough review — check every changed line.
+
+### 3a. Secrets & Credentials
+
+- API keys, tokens, passwords, private keys in code or config
+- Hardcoded connection strings with credentials
+- `.env` files or secrets committed to the repo
+- Hardcoded URLs with embedded auth tokens
+
+### 3b. Injection Vulnerabilities
+
+- **Command injection**: unsanitized input passed to subprocess calls or shell execution
+- **SQL injection**: string concatenation in queries instead of parameterized queries
+- **Path traversal**: user input used in file paths without sanitization
+- **XSS**: unescaped user input rendered in HTML/templates
+- **Template injection**: user input in format strings or template engines
+
+### 3c. Dependency Security
+
+- New dependencies added — check if they are well-maintained and trustworthy
+- Pinned versions vs. unpinned (prefer pinned)
+- Known vulnerabilities in added packages
+
+### 3d. Unsafe Operations
+
+- File operations without proper error handling or atomic writes
+- Unsafe deserialization (e.g., loading untrusted serialized objects)
+- Use of eval/exec with untrusted data
+- Weak cryptographic algorithms (MD5, SHA1 for security purposes)
+- Hardcoded salts, IVs, or crypto keys
+
+### 3e. Auth & Permissions
+
+- Missing authentication checks on new endpoints/commands
+- Privilege escalation paths
+- Overly permissive file permissions
+- CORS misconfigurations
+
+## Step 4: Documentation Review
+
+Check that all documentation is consistent with the PR changes.
+
+### 4a. README.md
+
+- If new features or commands were added, is README updated?
+- If existing features changed, does README reflect the change?
+- Are usage examples accurate?
+
+### 4b. docs/ Pages
+
+- For new CLI commands: is there a corresponding `docs/cli/<command>.md`?
+- For API changes: is the relevant `docs/api/*.md` page updated?
+- For new guides or concepts: are they added to `docs/guides/` or `docs/getting-started/`?
+- Do navigation references (mkdocs.yml or index pages) include new pages?
+
+### 4c. CHANGELOG.md
+
+- Is there a changelog entry for user-facing changes?
+- Does the entry accurately describe what changed?
+
+### 4d. CLI Help Text
+
+- If commands were added or modified, does the command's help text match the docs?
+- Is the skill file (`src/crux_cli/data/skills/crux/SKILL.md`) updated if commands changed?
+
+## Step 5: Verdict
+
+Collect all findings from Steps 2–4. Classify each finding by severity:
+
+| Severity | Meaning | Blocks merge? |
+|----------|---------|---------------|
+| **CRITICAL** | Security vulnerability, data loss risk, broken logic | Yes |
+| **WARNING** | Code smell, missing tests, incomplete docs | No |
+| **NIT** | Style, naming, minor suggestion | No |
+
+### 5a. Post Review
+
+Submit a single PR review via `gh pr review` that includes:
+
+1. **Inline comments** on specific lines for each finding (use `gh api` to post review comments on specific files/lines)
+2. **Summary comment** with a findings table:
+
+```markdown
+## PR Review Summary
+
+| # | Severity | Category | Finding |
+|---|----------|----------|---------|
+| 1 | CRITICAL | Security | API key hardcoded in config.py:42 |
+| 2 | WARNING  | Tests    | No test for error path in sync.py:89 |
+| 3 | NIT      | Style    | Unused import in utils.py:3 |
+
+**Verdict**: <APPROVE / REQUEST CHANGES>
+```
+
+### 5b. Decision
+
+```bash
+# If ANY critical finding exists:
+gh pr review <PR#> --request-changes --body "<summary>"
+
+# If only warnings/nits (no criticals):
+gh pr review <PR#> --comment --body "<summary>"
+
+# If clean (no findings at all):
+gh pr review <PR#> --approve --body "All checks pass. Code, security, and docs look good."
+```
+
+## Notes
+
+- This skill requires `gh` CLI authenticated with repo access
+- For large PRs (>1000 lines), focus on the most critical files first
+- When reviewing multiple PRs, post results for each before moving to the next
+- If a PR has already been reviewed and no new commits were pushed, skip it


### PR DESCRIPTION
## Summary

Add three new Claude Code skills for automated PR workflows: `review-pr` (multi-phase code review with CI gate, security audit, and docs check), `create-pr` (structured PR descriptions optimized for automated review), and `release-version` (version bump on main with release and docs pipeline orchestration).

## Changes

### Source
- No source code changes — skills only.

### Tests
- No test changes — skills are markdown instruction files.

### Docs
- `.claude/skills/review-pr/SKILL.md`: New skill — 5-step PR review process (CI gate → code review → security review → docs review → verdict)
- `.claude/skills/create-pr/SKILL.md`: New skill — structured PR description format with sections for changes, breaking changes, security considerations
- `.claude/skills/release-version/SKILL.md`: New skill — bump version in pyproject.toml, tag, release pipeline, docs pipeline

### Config
- No config changes.

## Breaking Changes

None.

## Security Considerations

None — these are instruction files, not executable code.

## Test Plan

- [ ] Skills are valid markdown with correct frontmatter
- [ ] `/review-pr`, `/create-pr`, `/release-version` appear in skill list
- [ ] No source or test changes to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)