### PR TITLE
feat: add address-issues skill for automated issue resolution

### DIFF
--- a/.claude/skills/address-issues/SKILL.md
+++ b/.claude/skills/address-issues/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: address-issues
+description: "Iterate all open GitHub issues: triage, reproduce, fix with tests, create PR, review. Fully automated issue resolution."
+args: ""
+---
+
+# Address Issues
+
+Iterate all open GitHub issues on the current repo. For each issue: triage, gather context, reproduce, implement a fix with tests, create a PR via `/create-pr`, and review via `/review-pr`.
+
+## Step 0: Fetch All Open Issues
+
+```bash
+gh issue list --state open --json number,title,body,labels --limit 100
+```
+
+Process each issue sequentially through Steps 1–7. Return to main branch before starting each issue.
+
+```bash
+git checkout main && git pull
+```
+
+## Step 1: Triage
+
+Read the issue title, body, and labels. Classify into one of:
+
+| Category | Description | Branch prefix |
+|----------|-------------|---------------|
+| **bug** | Something is broken or behaving incorrectly | `fix/` |
+| **feature** | New functionality or enhancement | `feat/` |
+| **docs** | Documentation improvement or correction | `docs/` |
+| **chore** | Maintenance, deps, config, refactoring | `chore/` |
+| **skip** | Too large, ambiguous, needs human decision, or requires external access | — |
+
+### If skip:
+
+Post a comment explaining why, then move to the next issue:
+
+```bash
+gh issue comment <NUMBER> --body "This issue requires human attention — <reason>. Skipping automated resolution."
+```
+
+## Step 2: Gather Context
+
+Read the issue thoroughly. Identify:
+
+- **Affected files**: which source files, tests, or docs are relevant
+- **Repro steps**: how to trigger the issue (from the issue body or inferred)
+- **Related code**: read the relevant source files to understand current behavior
+- **Linked issues/PRs**: check for related context
+
+```bash
+gh issue view <NUMBER> --json title,body,labels,comments
+```
+
+Read all affected source files to understand the code before making changes.
+
+## Step 3: Reproduce
+
+Verify the issue is real before attempting a fix.
+
+**For bugs:**
+- Follow the repro steps from the issue
+- Run existing tests that cover the affected code
+- Write a minimal failing test if no repro steps are provided
+
+```bash
+# Run relevant tests
+uv run pytest tests/ -k "<relevant_test_pattern>" -v
+```
+
+**For features/docs/chore:**
+- Verify the current state (missing feature, outdated docs, etc.)
+- Establish a baseline of current behavior
+
+### If reproduction fails:
+
+Post a comment and move to the next issue:
+
+```bash
+gh issue comment <NUMBER> --body "Attempted to reproduce this issue but was unable to.
+
+**What was tried:**
+- <list steps attempted>
+
+Please provide additional reproduction steps if possible."
+```
+
+## Step 4: Create Branch and Implement Fix
+
+Create a branch based on the triage category:
+
+```bash
+git checkout -b <prefix>/issue-<NUMBER>
+# Examples: fix/issue-42, feat/issue-15, docs/issue-7
+```
+
+### Implementation guidelines:
+
+- **Bug fixes**: fix the root cause, not just the symptom
+- **Features**: implement the minimum viable version described in the issue
+- **Docs**: update the relevant documentation files
+- **Chore**: make the maintenance change described
+
+### Tests:
+
+Every fix MUST include tests:
+
+- **Bug fix**: add a test that fails without the fix and passes with it
+- **Feature**: add tests covering the new functionality and edge cases
+- **Docs**: verify any code examples in docs are accurate
+- **Chore**: update existing tests if behavior changed
+
+Verify all tests pass:
+
+```bash
+uv run pytest tests/ -v
+uv run ruff check src/ tests/
+```
+
+## Step 5: Commit and Push
+
+```bash
+git add <changed-files>
+git commit -m "<prefix>: <concise description> (closes #<NUMBER>)"
+git push -u origin HEAD
+```
+
+The commit message prefix should match the branch prefix (`fix:`, `feat:`, `docs:`, `chore:`).
+
+## Step 6: Create PR
+
+Invoke the `/create-pr` skill. Ensure the PR body includes `Closes #<NUMBER>` to auto-close the issue on merge.
+
+## Step 7: Review PR
+
+Invoke the `/review-pr` skill on the newly created PR.
+
+### Review retry loop:
+
+1. **Approved or warnings-only** → done. Move to the next issue.
+2. **Critical findings** → read the review comments, fix the issues on the same branch:
+
+```bash
+# Fix the issues identified in review
+# ... make changes ...
+git add <files>
+git commit -m "fix: address review feedback for #<NUMBER>"
+git push
+```
+
+Then re-invoke `/review-pr`. Maximum **2 retry attempts**. After that, leave the PR as-is for human review.
+
+## Step 8: Next Issue
+
+Return to main and proceed to the next issue:
+
+```bash
+git checkout main && git pull
+```
+
+Repeat from Step 1 for the next issue.
+
+## Summary Output
+
+After processing all issues, output a summary table:
+
+```markdown
+| Issue | Title | Action | Result |
+|-------|-------|--------|--------|
+| #42 | Broken sync | fix | PR #51 created, approved |
+| #15 | Add search | skip | Too large for automated fix |
+| #7 | Typo in docs | docs | PR #52 created, approved |
+| #3 | Crash on empty | fix | PR #53 created, review pending |
+```
+
+## Notes
+
+- This skill requires `gh` CLI authenticated with repo access
+- Each issue gets its own branch and PR — no combining issues
+- Always return to main between issues to avoid cross-contamination
+- The skill invokes `/create-pr` and `/review-pr` — those skills handle the details of PR formatting and review process

--- a/docs/superpowers/specs/2026-03-23-address-issues-design.md
+++ b/docs/superpowers/specs/2026-03-23-address-issues-design.md
@@ -1,0 +1,71 @@
+# Address Issues Skill — Design Spec
+
+**Date:** 2026-03-23
+**Status:** Approved
+
+## Summary
+
+A skill that iterates all open GitHub issues on the current repo, triages each one, and for addressable issues: reproduces the problem, implements a fix with tests on a dedicated branch, creates a PR via `/create-pr`, and reviews it via `/review-pr` with up to 2 fix-retry cycles.
+
+## Flow
+
+```
+For each open issue:
+  1. Triage → bug / feature / docs / chore / skip
+  2. If skip → comment on issue with reason, move to next
+  3. Gather context (issue body, linked files, related code)
+  4. Reproduce (run tests, follow repro steps from issue)
+  5. If repro fails → comment on issue, move to next
+  6. Create branch: <category>/issue-<number>
+  7. Implement fix + add/update tests
+  8. Commit, push, invoke /create-pr
+  9. Invoke /review-pr
+  10. If critical findings → fix and re-review (max 2 retries)
+  11. Move to next issue
+```
+
+## Branch Naming
+
+Based on triage category:
+
+| Category | Branch prefix | Example |
+|----------|--------------|---------|
+| Bug | `fix/` | `fix/issue-42` |
+| Feature | `feat/` | `feat/issue-42` |
+| Docs | `docs/` | `docs/issue-42` |
+| Chore | `chore/` | `chore/issue-42` |
+
+## Triage Criteria
+
+Each issue is categorized by reading the title, body, and labels. Issues that meet any of the following are marked **skip**:
+
+- Too large or ambiguous to address in a single PR
+- Requires external service access or infrastructure changes
+- Requires human design decisions (e.g., UX, architecture)
+- Duplicate of another issue already being addressed
+
+Skipped issues receive a comment: *"This issue requires human attention — [reason]. Skipping automated resolution."*
+
+## Reproduction
+
+For bugs: attempt to reproduce using steps from the issue body, running existing tests, or writing a minimal repro script. For features/docs/chore: verify current behavior to establish a baseline.
+
+If reproduction fails, comment on the issue: *"Attempted to reproduce this issue but was unable to. [details of what was tried]. Please provide additional reproduction steps if possible."* Then move to the next issue.
+
+## Review Retry Loop
+
+After `/review-pr` runs:
+
+1. If approved or warnings-only → done, move to next issue
+2. If critical findings → read review comments, attempt fixes on the same branch, push, re-invoke `/review-pr`
+3. Maximum 2 retry attempts — after that, leave the PR as-is for human review
+
+## PR Linking
+
+Every PR body includes `Closes #<issue-number>` so merging auto-closes the issue.
+
+## Dependencies
+
+- `gh` CLI authenticated with repo access
+- `/create-pr` skill
+- `/review-pr` skill


### PR DESCRIPTION
## Summary

Adds a new `address-issues` skill that iterates all open GitHub issues, triages each one (bug/feature/docs/chore/skip), reproduces the problem, implements a fix with tests on a dedicated branch, creates a PR via `/create-pr`, and reviews via `/review-pr` with up to 2 retry cycles.

## Changes

### Source
No source changes

### Tests
No test changes

### Docs
- `docs/superpowers/specs/2026-03-23-address-issues-design.md`: Design spec documenting the skill's flow, triage criteria, branch naming, repro failure handling, and review retry loop

### Config
No config changes

### Skills
- `.claude/skills/address-issues/SKILL.md`: New skill with 8-step workflow — fetch issues, triage, gather context, reproduce, implement fix + tests, commit/push, create PR via `/create-pr`, review via `/review-pr` with retry loop, summary output

## Breaking Changes

None

## Security Considerations

The skill executes `gh issue comment` to post comments on issues and delegates to `/create-pr` and `/review-pr` for PR operations. All GitHub operations use the authenticated `gh` CLI — no secrets or tokens are handled directly.

## Test Plan

- [ ] All unit tests pass (`uv run pytest tests/unit/ -v`)
- [ ] All integration tests pass (`uv run pytest tests/integration/ -v`)
- [ ] Ruff clean (`uv run ruff check src/ tests/`)
- [ ] Coverage maintained (>90%)
- [ ] No secrets in committed files
- [ ] Skill appears in Claude Code skill list after sync
- [ ] Skill frontmatter (name, description, args) is well-formed

🤖 Generated with [Claude Code](https://claude.com/claude-code)