### PR TITLE
feat: add issue linking to create-pr and review-pr skills

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -33,7 +33,18 @@ git diff ${BASE}...HEAD --stat
 
 # Changed files
 gh api repos/:owner/:repo/compare/${BASE}...${BRANCH} --jq '.files[].filename'
+
+# Check for a related issue (by branch name pattern like fix/issue-42 or feat/issue-15)
+# Extract issue number if the branch follows <prefix>/issue-<number> convention
+ISSUE_NUM=$(echo "$BRANCH" | grep -oE 'issue-[0-9]+' | grep -oE '[0-9]+')
+if [ -n "$ISSUE_NUM" ]; then
+  gh issue view "$ISSUE_NUM" --json number,title,body,labels
+fi
 ```
+
+### Linked Issue
+
+If the branch name contains an issue number (e.g., `fix/issue-42`), or if commit messages reference an issue (`closes #42`, `fixes #42`), fetch the issue details. The PR body should include `Closes #<number>` to auto-close the issue on merge.
 
 ## Step 2: Analyze Changes
 
@@ -53,6 +64,10 @@ Use this exact format. Every section is required. The `/review-pr` skill parses 
 ## Summary
 
 <1-3 sentences: what this PR does and why>
+
+## Linked Issue
+
+<If this PR addresses a GitHub issue, write "Closes #<number>" and include a one-line summary of the issue. Write "None" if no issue is linked.>
 
 ## Changes
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -64,6 +64,22 @@ Also read the PR description and any linked issues for context:
 gh pr view <PR#> --json title,body,labels,files
 ```
 
+### 2.0: Check Linked Issue
+
+If the PR body contains `Closes #<number>` or `Fixes #<number>`, fetch the linked issue:
+
+```bash
+gh issue view <ISSUE#> --json number,title,body,labels
+```
+
+Use the issue description to:
+
+- **Verify the fix matches the reported problem** — does the PR actually address what the issue describes?
+- **Check repro steps are covered** — if the issue includes repro steps, are they addressed by the changes or covered by tests?
+- **Validate scope** — does the PR stay within the scope of what the issue requested, or does it include unrelated changes?
+
+If the PR claims to close an issue but the changes don't address it, flag this as a **WARNING** finding.
+
 ### 2a. Logic & Correctness
 
 Review every changed file for:


### PR DESCRIPTION
## Summary

Enhances `/create-pr` and `/review-pr` skills with GitHub issue linking. PRs created from issue branches now automatically reference the issue, and reviews now verify the PR actually addresses the linked issue.

## Linked Issue

None — this is a skill enhancement requested during the `/address-issues` workflow.

## Changes

### Source
No source changes

### Tests
No test changes

### Docs
No doc changes

### Config
No config changes

### Skills
- `.claude/skills/create-pr/SKILL.md`: Added issue detection from branch names and commit messages, new "Linked Issue" section in PR template, `Closes #<number>` guidance
- `.claude/skills/review-pr/SKILL.md`: Added Step 2.0 "Check Linked Issue" — fetches issue description and verifies the PR addresses the reported problem, covers repro steps, and stays within scope

## Breaking Changes

None

## Security Considerations

None

## Test Plan

- [ ] All unit tests pass (`uv run pytest tests/unit/ -v`)
- [ ] All integration tests pass (`uv run pytest tests/integration/ -v`)
- [ ] Ruff clean (`uv run ruff check src/ tests/`)
- [ ] Coverage maintained (>90%)
- [ ] No secrets in committed files
- [ ] Skills load correctly in Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)