### PR TITLE
feat: clean up keychain secrets on mcp remove

### DIFF
--- a/src/crux_cli/cli/commands/mcp.py
+++ b/src/crux_cli/cli/commands/mcp.py
@@ -147,7 +147,56 @@ def cmd_mcp_remove(args: argparse.Namespace) -> None:
     del reg[section][name]
     save_registry(reg)
     print(f"\u2705 Removed MCP '{name}' from registry")
+
+    # Clean up keychain secrets if the MCP had auth configured
+    _cleanup_secrets(name, data, args)
+
     print("   Note: run 'crux project sync' to regenerate project configurations")
+
+
+def _cleanup_secrets(name: str, data: dict[str, Any], args: argparse.Namespace) -> None:
+    """Prompt to remove keychain secrets for a removed MCP, respecting CLI flags."""
+    from crux_cli.secrets import get_backend, load_secrets_index
+
+    auth = data.get("auth", {})
+    env_vars = auth.get("env_vars", [])
+    if not env_vars:
+        return
+
+    backend = get_backend()
+    stored = [v for v in env_vars if backend.get(name, v)]
+    if not stored:
+        return
+
+    keep_secrets = getattr(args, "keep_secrets", False)
+    remove_secrets = getattr(args, "remove_secrets", False)
+
+    if keep_secrets:
+        should_remove = False
+    elif remove_secrets:
+        should_remove = True
+    elif sys.stdin.isatty():
+        print(f"  \U0001f511 Found {len(stored)} stored secret(s): {', '.join(stored)}")
+        answer = input("  Also remove secrets from keychain? [Y/n]: ").strip().lower()
+        should_remove = answer != "n"
+    else:
+        # Non-interactive, no flag — default to keeping secrets
+        print(f"  \U0001f511 Found {len(stored)} secret(s) kept (use --remove-secrets to clean up)")
+        return
+
+    if should_remove:
+        for var in stored:
+            backend.delete(name, var)
+        # Clean up any remaining index entries for env vars that weren't stored
+        index = load_secrets_index()
+        if name in index:
+            index.pop(name, None)
+            from crux_cli.secrets import save_secrets_index
+
+            save_secrets_index(index)
+        print(f"  \U0001f5d1\ufe0f  Removed {len(stored)} secret(s) from keychain")
+    else:
+        print("  Kept secrets in keychain")
 
 
 def cmd_mcp_list(args: argparse.Namespace) -> None:

--- a/src/crux_cli/cli/main.py
+++ b/src/crux_cli/cli/main.py
@@ -61,6 +61,9 @@ def main() -> None:
 
     p = mcp_sub.add_parser("remove", help="Unregister an MCP server")
     p.add_argument("name", help="Name to remove")
+    secrets_group = p.add_mutually_exclusive_group()
+    secrets_group.add_argument("--keep-secrets", action="store_true", help="Keep keychain secrets (no prompt)")
+    secrets_group.add_argument("--remove-secrets", action="store_true", help="Remove keychain secrets (no prompt)")
     p.set_defaults(func=cmd_mcp_remove)
 
     p = mcp_sub.add_parser("list", help="List registered MCP servers")

--- a/tests/integration/test_cli_mcp.py
+++ b/tests/integration/test_cli_mcp.py
@@ -68,6 +68,25 @@ class TestMcpRemove:
         result = run_crux("mcp", "remove", "nope", env=env)
         assert result.returncode != 0
 
+    def test_remove_with_keep_secrets_flag(self, crux_env):
+        env, root = crux_env
+        run_crux("mcp", "add", "authed", "--npx", "@test/authed", "--keychain", "KEY1,KEY2", env=env)
+        result = run_crux("mcp", "remove", "authed", "--keep-secrets", env=env)
+        assert result.returncode == 0
+        assert "Removed" in result.stdout
+
+    def test_remove_with_remove_secrets_flag(self, crux_env):
+        env, root = crux_env
+        run_crux("mcp", "add", "authed2", "--npx", "@test/authed2", "--keychain", "KEY1", env=env)
+        result = run_crux("mcp", "remove", "authed2", "--remove-secrets", env=env)
+        assert result.returncode == 0
+        assert "Removed" in result.stdout
+
+    def test_remove_secrets_flags_mutually_exclusive(self, crux_env):
+        env, root = crux_env
+        result = run_crux("mcp", "remove", "x", "--keep-secrets", "--remove-secrets", env=env)
+        assert result.returncode != 0
+
 
 @pytest.mark.integration
 class TestMcpList:

--- a/tests/unit/test_mcp_remove_secrets.py
+++ b/tests/unit/test_mcp_remove_secrets.py
@@ -11,13 +11,6 @@ from crux_cli.cli.commands.mcp import _cleanup_secrets
 
 
 @pytest.fixture
-def mock_backend():
-    backend = MagicMock()
-    backend.get.return_value = "some-value"
-    return backend
-
-
-@pytest.fixture
 def mcp_data_with_secrets():
     return {
         "auth": {

--- a/tests/unit/test_mcp_remove_secrets.py
+++ b/tests/unit/test_mcp_remove_secrets.py
@@ -1,0 +1,134 @@
+"""Tests for secret cleanup during crux mcp remove."""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from crux_cli.cli.commands.mcp import _cleanup_secrets
+
+
+@pytest.fixture
+def mock_backend():
+    backend = MagicMock()
+    backend.get.return_value = "some-value"
+    return backend
+
+
+@pytest.fixture
+def mcp_data_with_secrets():
+    return {
+        "auth": {
+            "type": "keychain",
+            "env_vars": ["API_KEY", "SECRET_TOKEN"],
+        }
+    }
+
+
+@pytest.fixture
+def mcp_data_no_auth():
+    return {}
+
+
+class TestCleanupSecrets:
+    def test_no_auth_block_does_nothing(self, mcp_data_no_auth):
+        args = argparse.Namespace(keep_secrets=False, remove_secrets=False)
+        _cleanup_secrets("test-mcp", mcp_data_no_auth, args)
+
+    def test_no_env_vars_does_nothing(self):
+        data = {"auth": {"type": "external-cli"}}
+        args = argparse.Namespace(keep_secrets=False, remove_secrets=False)
+        _cleanup_secrets("test-mcp", data, args)
+
+    @patch("crux_cli.secrets.get_backend")
+    def test_no_stored_secrets_does_nothing(self, mock_get_backend, mcp_data_with_secrets):
+        backend = MagicMock()
+        backend.get.return_value = None
+        mock_get_backend.return_value = backend
+        args = argparse.Namespace(keep_secrets=False, remove_secrets=False)
+        _cleanup_secrets("test-mcp", mcp_data_with_secrets, args)
+        backend.delete.assert_not_called()
+
+    @patch("crux_cli.secrets.save_secrets_index")
+    @patch("crux_cli.secrets.load_secrets_index", return_value={})
+    @patch("crux_cli.secrets.get_backend")
+    def test_remove_secrets_flag_deletes_all(self, mock_get_backend, _mock_idx, _mock_save, mcp_data_with_secrets):
+        backend = MagicMock()
+        backend.get.return_value = "stored-value"
+        mock_get_backend.return_value = backend
+        args = argparse.Namespace(keep_secrets=False, remove_secrets=True)
+        _cleanup_secrets("test-mcp", mcp_data_with_secrets, args)
+        assert backend.delete.call_count == 2
+        backend.delete.assert_any_call("test-mcp", "API_KEY")
+        backend.delete.assert_any_call("test-mcp", "SECRET_TOKEN")
+
+    @patch("crux_cli.secrets.get_backend")
+    def test_keep_secrets_flag_skips_deletion(self, mock_get_backend, mcp_data_with_secrets, capsys):
+        backend = MagicMock()
+        backend.get.return_value = "stored-value"
+        mock_get_backend.return_value = backend
+        args = argparse.Namespace(keep_secrets=True, remove_secrets=False)
+        _cleanup_secrets("test-mcp", mcp_data_with_secrets, args)
+        backend.delete.assert_not_called()
+        assert "Kept secrets" in capsys.readouterr().out
+
+    @patch("crux_cli.secrets.save_secrets_index")
+    @patch("crux_cli.secrets.load_secrets_index", return_value={"test-mcp": ["API_KEY", "SECRET_TOKEN"]})
+    @patch("crux_cli.secrets.get_backend")
+    @patch("builtins.input", return_value="")
+    @patch("sys.stdin")
+    def test_interactive_yes_default(
+        self,
+        mock_stdin,
+        _mock_input,
+        mock_get_backend,
+        _mock_idx,
+        _mock_save,
+        mcp_data_with_secrets,
+        capsys,
+    ):
+        mock_stdin.isatty.return_value = True
+        backend = MagicMock()
+        backend.get.return_value = "stored-value"
+        mock_get_backend.return_value = backend
+        args = argparse.Namespace(keep_secrets=False, remove_secrets=False)
+        _cleanup_secrets("test-mcp", mcp_data_with_secrets, args)
+        assert backend.delete.call_count == 2
+        assert "Removed 2 secret(s)" in capsys.readouterr().out
+
+    @patch("crux_cli.secrets.get_backend")
+    @patch("builtins.input", return_value="n")
+    @patch("sys.stdin")
+    def test_interactive_no(self, mock_stdin, _mock_input, mock_get_backend, mcp_data_with_secrets, capsys):
+        mock_stdin.isatty.return_value = True
+        backend = MagicMock()
+        backend.get.return_value = "stored-value"
+        mock_get_backend.return_value = backend
+        args = argparse.Namespace(keep_secrets=False, remove_secrets=False)
+        _cleanup_secrets("test-mcp", mcp_data_with_secrets, args)
+        backend.delete.assert_not_called()
+        assert "Kept secrets" in capsys.readouterr().out
+
+    @patch("crux_cli.secrets.get_backend")
+    @patch("sys.stdin")
+    def test_non_interactive_keeps_secrets(self, mock_stdin, mock_get_backend, mcp_data_with_secrets, capsys):
+        mock_stdin.isatty.return_value = False
+        backend = MagicMock()
+        backend.get.return_value = "stored-value"
+        mock_get_backend.return_value = backend
+        args = argparse.Namespace(keep_secrets=False, remove_secrets=False)
+        _cleanup_secrets("test-mcp", mcp_data_with_secrets, args)
+        backend.delete.assert_not_called()
+        assert "kept" in capsys.readouterr().out
+
+    @patch("crux_cli.secrets.get_backend")
+    def test_partially_stored_only_counts_stored(self, mock_get_backend, mcp_data_with_secrets, capsys):
+        """Only secrets that are actually stored are counted."""
+        backend = MagicMock()
+        backend.get.side_effect = lambda name, key: "val" if key == "API_KEY" else None
+        mock_get_backend.return_value = backend
+        args = argparse.Namespace(keep_secrets=True, remove_secrets=False)
+        _cleanup_secrets("test-mcp", mcp_data_with_secrets, args)
+        assert "Kept secrets" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

When removing an MCP with stored keychain secrets, `crux mcp remove` now detects orphaned secrets and prompts the user to clean them up. Adds `--keep-secrets` and `--remove-secrets` flags for non-interactive use.

## Linked Issue

Closes #24 — `crux mcp remove` leaves keychain secrets and secrets index entries behind as orphans.

## Changes

### Source
- `src/crux_cli/cli/commands/mcp.py`: Added `_cleanup_secrets()` helper called after registry removal. Checks for stored secrets via the backend, prompts interactively (Y/n default), and respects `--keep-secrets`/`--remove-secrets` flags. Non-interactive sessions default to keeping secrets with an informational message.
- `src/crux_cli/cli/main.py`: Added `--keep-secrets` and `--remove-secrets` as mutually exclusive flags to the `mcp remove` subparser.

### Tests
- `tests/unit/test_mcp_remove_secrets.py`: 9 unit tests covering: no auth, no env vars, no stored secrets, `--remove-secrets` flag, `--keep-secrets` flag, interactive yes (default), interactive no, non-interactive fallback, and partially stored secrets.
- `tests/integration/test_cli_mcp.py`: 3 integration tests covering: `--keep-secrets` flag, `--remove-secrets` flag, and mutual exclusivity of both flags.

### Docs
No doc changes

### Config
No config changes

## Breaking Changes

None — existing `crux mcp remove <name>` behavior is unchanged for MCPs without keychain auth. For MCPs with stored secrets, a new interactive prompt appears (defaulting to Y), but non-interactive sessions silently keep secrets to avoid breaking scripts.

## Security Considerations

- Secrets are deleted from the OS keychain/Secret Service via `backend.delete()`, using the same secure path as `crux mcp auth`.
- The secrets index (`~/.crux/secrets.json`) is cleaned up atomically after secret deletion.
- No secrets are logged or printed — only key names are shown.

## Test Plan

- [x] All unit tests pass (`uv run pytest tests/unit/ -v`)
- [x] All integration tests pass (`uv run pytest tests/integration/ -v`)
- [x] Ruff clean (`uv run ruff check src/ tests/`)
- [x] No secrets in committed files
- [ ] Manual: `crux mcp add test --npx pkg --keychain KEY1,KEY2 && crux mcp auth test && crux mcp remove test` — verify prompt appears
- [ ] Manual: `crux mcp remove test --remove-secrets` — verify no prompt, secrets deleted
- [ ] Manual: `crux mcp remove test --keep-secrets` — verify no prompt, secrets kept

🤖 Generated with [Claude Code](https://claude.com/claude-code)